### PR TITLE
Add path urls to repo parser output

### DIFF
--- a/create_project.py
+++ b/create_project.py
@@ -40,7 +40,8 @@ class GitHubRepoParser:
             else:
                 result['children'].append({
                     'name': item['name'],
-                    'type': 'file'
+                    'type': 'file',
+                    'path': item.get('html_url') or item.get('download_url')
                 })
 
         return result

--- a/src/components/global/GitHubViewer.tsx
+++ b/src/components/global/GitHubViewer.tsx
@@ -6,6 +6,7 @@ import DraggableWindow from './DraggableWindow';
 type FileNode = {
   name: string;
   type: 'file' | 'directory';
+  path?: string;
   children?: readonly FileNode[];
 };
 
@@ -65,7 +66,19 @@ const GitHubViewer = ({ isOpen, onClose }: GitHubViewerProps) => {
           ) : (
             <FaFile className="text-blue-400 mr-2" />
           )}
-          <span className="text-gray-200">{node.name}</span>
+          {node.type === 'file' && node.path ? (
+            <a
+              href={node.path}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-gray-200 hover:underline"
+              onClick={(e) => e.stopPropagation()}
+            >
+              {node.name}
+            </a>
+          ) : (
+            <span className="text-gray-200">{node.name}</span>
+          )}
         </div>
         {node.type === 'directory' && isExpanded && node.children && (
           <div className="ml-4">

--- a/util/github_repo_parser.py
+++ b/util/github_repo_parser.py
@@ -39,7 +39,8 @@ class GitHubRepoParser:
             else:
                 result['children'].append({
                     'name': item['name'],
-                    'type': 'file'
+                    'type': 'file',
+                    'path': item.get('html_url') or item.get('download_url')
                 })
 
         return result


### PR DESCRIPTION
## Summary
- include GitHub file url in `parse_directory`
- expose new `path` field through project JSON
- allow GitHub viewer to show links for files

## Testing
- `npm run build` *(fails: astro not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f2c634510833083f3d9c4928a9c24