### PR TITLE
Hide notes and spotify

### DIFF
--- a/src/components/global/DesktopDock.tsx
+++ b/src/components/global/DesktopDock.tsx
@@ -1,9 +1,9 @@
 import { useState, useEffect, useRef } from 'react';
-import { BsGithub, BsSpotify, BsFilePdf, BsStickyFill, BsLinkedin, BsCalendar } from 'react-icons/bs';
+import { BsGithub, BsFilePdf, BsLinkedin, BsCalendar } from 'react-icons/bs';
 import { IoIosCall, IoIosMail } from 'react-icons/io';
 import { FaLink, FaEnvelope } from 'react-icons/fa';
 import ResumeViewer from './ResumeViewer';
-import SpotifyPlayer from './SpotifyPlayer';
+// import SpotifyPlayer from './SpotifyPlayer';
 import { userConfig } from '../../config/userConfig';
 import { RiTerminalFill } from 'react-icons/ri';
 
@@ -23,7 +23,6 @@ interface DesktopDockProps {
 const DesktopDock = ({ onTerminalClick, onNotesClick, onGitHubClick, activeApps }: DesktopDockProps) => {
   const [hoveredIcon, setHoveredIcon] = useState<string | null>(null);
   const [showResume, setShowResume] = useState(false);
-  const [showSpotify, setShowSpotify] = useState(false);
   const [showLinksPopup, setShowLinksPopup] = useState(false);
   const linksPopupRef = useRef<HTMLDivElement>(null);
 
@@ -31,9 +30,6 @@ const DesktopDock = ({ onTerminalClick, onNotesClick, onGitHubClick, activeApps 
     setShowLinksPopup(!showLinksPopup);
   };
 
-  const handleSpotifyClick = () => {
-    setShowSpotify(true);
-  };
 
   const handleResumeClick = () => {
     setShowResume(true);
@@ -43,9 +39,6 @@ const DesktopDock = ({ onTerminalClick, onNotesClick, onGitHubClick, activeApps 
     setShowResume(false);
   };
 
-  const handleCloseSpotify = () => {
-    setShowSpotify(false);
-  };
 
   const handleEmailClick = () => {
     window.open(`mailto:${userConfig.contact.email}`, '_blank');
@@ -131,6 +124,7 @@ const DesktopDock = ({ onTerminalClick, onNotesClick, onGitHubClick, activeApps 
             </button>
 
             {/* Notes */}
+            {/**
             <button
               onClick={onNotesClick}
               onMouseEnter={() => setHoveredIcon('notes')}
@@ -142,6 +136,7 @@ const DesktopDock = ({ onTerminalClick, onNotesClick, onGitHubClick, activeApps 
               </div>
               {hoveredIcon === 'notes' && <Tooltip text='Lab Notes & Archives' />}
             </button>
+            */}
 
             {/* Resume */}
             <button
@@ -156,6 +151,7 @@ const DesktopDock = ({ onTerminalClick, onNotesClick, onGitHubClick, activeApps 
               {hoveredIcon === 'resume' && <Tooltip text='View Resume' />}
             </button>
             {/* Spotify */}
+            {/**
             <button
               onClick={handleSpotifyClick}
               onMouseEnter={() => setHoveredIcon('spotify')}
@@ -167,6 +163,7 @@ const DesktopDock = ({ onTerminalClick, onNotesClick, onGitHubClick, activeApps 
               </div>
               {hoveredIcon === 'spotify' && <Tooltip text='Spotify Playlist' />}
             </button>
+            */}
 
             {/* Email */}
             <button
@@ -212,11 +209,13 @@ const DesktopDock = ({ onTerminalClick, onNotesClick, onGitHubClick, activeApps 
       </div>
 
       <ResumeViewer isOpen={showResume} onClose={handleCloseResume} />
+      {/**
       <SpotifyPlayer
         isOpen={showSpotify}
         onClose={handleCloseSpotify}
         playlistId={userConfig.spotify.playlistId}
       />
+      */}
     </>
   );
 };

--- a/src/components/global/HelpModal.tsx
+++ b/src/components/global/HelpModal.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import { IoClose } from 'react-icons/io5';
-import { BsGithub, BsSpotify, BsFilePdf, BsStickyFill, BsCalendar } from 'react-icons/bs';
+import { BsGithub, BsFilePdf, BsStickyFill, BsCalendar } from 'react-icons/bs';
 import { FaLink } from 'react-icons/fa';
 import { RiTerminalFill } from 'react-icons/ri';
 
@@ -54,10 +54,10 @@ export default function HelpModal({
       button: null,
       features: [
         { icon: <BsGithub size={20} />, text: "Our Projects" },
-        { icon: <BsStickyFill size={20} />, text: "Lab Archives" },
+        {/* { icon: <BsStickyFill size={20} />, text: "Lab Archives" }, */}
         { icon: <BsFilePdf size={20} />, text: "Resume Viewer" },
         { icon: <BsCalendar size={20} />, text: "Schedule a Call" },
-        { icon: <BsSpotify size={20} />, text: "Spotify Playlist" },
+        {/* { icon: <BsSpotify size={20} />, text: "Spotify Playlist" }, */}
         { icon: <FaLink size={20} />, text: "Contact Links" },
         { icon: <RiTerminalFill size={20} />, text: "Terminal" }
       ]

--- a/src/components/global/MobileDock.tsx
+++ b/src/components/global/MobileDock.tsx
@@ -1,7 +1,7 @@
-import { BsGithub, BsSpotify, BsLinkedin } from 'react-icons/bs';
+import { BsGithub, BsLinkedin } from 'react-icons/bs';
 import { IoIosMail, IoIosCall } from 'react-icons/io';
 import { userConfig } from '../../config/userConfig';
-import { BsStickyFill } from 'react-icons/bs';
+// import { BsStickyFill } from 'react-icons/bs';
 import { RiTerminalFill } from 'react-icons/ri';
 import { BsFilePdf } from 'react-icons/bs';
 
@@ -17,9 +17,6 @@ export default function MobileDock({ onGitHubClick, onNotesClick, onResumeClick,
     window.location.href = `mailto:${userConfig.contact.email}`;
   };
 
-  const handleSpotifyClick = () => {
-    window.open(`https://open.spotify.com/playlist/${userConfig.spotify.playlistId}`, '_blank');
-  };
 
   return (
     <div className='fixed bottom-0 left-0 right-0 md:hidden flex flex-col items-center z-10 space-y-2'>
@@ -33,6 +30,7 @@ export default function MobileDock({ onGitHubClick, onNotesClick, onResumeClick,
             <BsGithub size={55} className='text-white' />
           </div>
         </button>
+        {/**
         <button
           onClick={onNotesClick}
           className='flex flex-col items-center cursor-pointer'
@@ -41,6 +39,7 @@ export default function MobileDock({ onGitHubClick, onNotesClick, onResumeClick,
             <BsStickyFill size={55} className='text-white' />
           </div>
         </button>
+        */}
         <button
           onClick={onResumeClick}
           className='flex flex-col items-center cursor-pointer'
@@ -82,6 +81,7 @@ export default function MobileDock({ onGitHubClick, onNotesClick, onResumeClick,
           </div>
         </a>
 
+        {/**
         <button
           onClick={handleSpotifyClick}
           className='flex flex-col items-center cursor-pointer'
@@ -90,6 +90,7 @@ export default function MobileDock({ onGitHubClick, onNotesClick, onResumeClick,
             <BsSpotify size={55} className='text-[#1ED760]' />
           </div>
         </button>
+        */}
       </div>
     </div>
   );

--- a/src/layouts/AppLayout.tsx
+++ b/src/layouts/AppLayout.tsx
@@ -25,7 +25,6 @@ export default function Desktop({ initialBg, backgroundMap }: AppLayoutProps) {
   const [showNotes, setShowNotes] = useState(false);
   const [showGitHub, setShowGitHub] = useState(false);
   const [showResume, setShowResume] = useState(false);
-  const [showSpotify, setShowSpotify] = useState(false);
   const [currentTutorialStep, setCurrentTutorialStep] = useState(0);
   const [showTutorial, setShowTutorial] = useState(false);
 


### PR DESCRIPTION
## Summary
- comment out Lab Notes & Spotify buttons in desktop dock
- comment out Lab Notes & Spotify buttons in mobile dock
- comment out references in help modal
- remove unused spotify state

## Testing
- `npm run build` *(fails: astro not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a1ea07ec88330b7830688346faf1d