### PR TITLE
Fix comment syntax error

### DIFF
--- a/src/components/global/HelpModal.tsx
+++ b/src/components/global/HelpModal.tsx
@@ -54,10 +54,10 @@ export default function HelpModal({
       button: null,
       features: [
         { icon: <BsGithub size={20} />, text: "Our Projects" },
-        {/* { icon: <BsStickyFill size={20} />, text: "Lab Archives" }, */}
+        // { icon: <BsStickyFill size={20} />, text: "Lab Archives" },
         { icon: <BsFilePdf size={20} />, text: "Resume Viewer" },
         { icon: <BsCalendar size={20} />, text: "Schedule a Call" },
-        {/* { icon: <BsSpotify size={20} />, text: "Spotify Playlist" }, */}
+        // { icon: <BsSpotify size={20} />, text: "Spotify Playlist" },
         { icon: <FaLink size={20} />, text: "Contact Links" },
         { icon: <RiTerminalFill size={20} />, text: "Terminal" }
       ]


### PR DESCRIPTION
## Summary
- correct comment style in `HelpModal`

## Testing
- `npm run build` *(fails: astro not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a21ff6a388330aa150f657aae24ec