### PR TITLE
Add Cloudflare Pages support

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,15 @@ and select the image from the vercel dashboard.
 
 There is a bug with direct deployment from github, i can't seem to figure it out tbf, so for the time being use the above commands after running ```npm run build```.
 
+## Deploy to Cloudflare Pages
+
+Build the project and deploy the generated `dist` directory using Wrangler:
+
+```bash
+npm run build
+wrangler pages deploy ./dist --project-name <YOUR_PAGES_PROJECT_NAME>
+```
+
 ## 📁 Project Structure
 
 ```

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,0 +1,3 @@
+name = "sblwebsite"
+compatibility_date = "2024-06-29"
+pages_build_output_dir = "./dist"


### PR DESCRIPTION
## Summary
- add `wrangler.toml` specifying Pages output directory
- document Cloudflare Pages deployment in the README

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685a2aece7ac8330869d5c68e9adcdc4