### PR TITLE
Add React integration to Astro config

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -10,6 +10,7 @@ export default defineConfig({
   adapter: cloudflare(),
 
   integrations: [
+    react(),
     sitemap({
       serialize: (item) => {
         const url = item.url.endsWith('/') ? item.url.slice(0, -1) : item.url;


### PR DESCRIPTION
## Summary
- enable React integration before sitemap in `astro.config.mjs`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685b3fcbb2c88330bce613b543946642