### PR TITLE
Fix image import path

### DIFF
--- a/src/components/global/BaseHead.astro
+++ b/src/components/global/BaseHead.astro
@@ -3,7 +3,7 @@ import '../../styles/global.css';
 import { AstroSeo } from '@astrolib/seo';
 import { getImage } from 'astro:assets';
 import macBackground1 from '../../assets/images/mac-background1.jpg';
-import macBackground2 from '../../assets/images/mac-background3.jpg';
+import macBackground2 from '../../assets/images/mac-background2.jpg';
 import macBackground3 from '../../assets/images/mac-background3.jpg';
 import { userConfig } from '../../config/userConfig';
 


### PR DESCRIPTION
## Summary
- correct BaseHead import path for macBackground2 image

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685b47aebac88330b592143df8a87742