### PR TITLE
Fix clone URL in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ A modern, interactive portfolio website built with Astro, React, and Tailwind CS
 
 1. Clone the repository:
 ```bash
-git clone https://github.com/aabdoo23/portfolio
+git clone https://github.com/SpacebarLabsLLC/sblwebsite.git
 cd portfolio
 ```
 


### PR DESCRIPTION
## Summary
- replace the old portfolio URL in the install instructions with this repo's URL

## Testing
- `npm run build` *(fails: astro not found due to missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685b47f228ac83309d4ba63b83c70340